### PR TITLE
Configure MCP server settings

### DIFF
--- a/run-hf-mcp-server.sh
+++ b/run-hf-mcp-server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Usage: ./run-hf-mcp-server.sh <YOUR_HF_TOKEN>
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <YOUR_HF_TOKEN>"
+  exit 1
+fi
+
+HF_TOKEN="$1"
+
+npx mcp-remote https://huggingface.co/mcp --header "Authorization: Bearer $HF_TOKEN"


### PR DESCRIPTION
## Description

Created `run-hf-mcp-server.sh` script to simplify starting the Hugging Face Model Context Protocol (MCP) server. The script accepts the Hugging Face token as a command-line argument, promoting secure handling of credentials.

## How Has This Been Tested?

The script was generated and placed in the workspace. The assistant confirmed successful creation and provided usage instructions.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

## Summary by Sourcery

New Features:
- Add run-hf-mcp-server.sh to simplify and secure launching of the Hugging Face Model Context Protocol server using a provided token